### PR TITLE
Allow :as :text/:stream/:byte-array

### DIFF
--- a/src/clj_okhttp/middleware.clj
+++ b/src/clj_okhttp/middleware.clj
@@ -57,12 +57,8 @@
 
 (defn wrap-decode-responses [handler]
   (letfn [(prepare-response [{:keys [muuntaja as]} {:keys [body] :as response}]
-            (if (some? as)
-              (let [decoded (mun/format-stream muuntaja as body)]
-                (assoc response :body decoded))
-              (let [as      (get-in response [:headers "content-type"])
-                    decoded (mun/format-stream muuntaja as body)]
-                (assoc response :body decoded))))]
+            (let [decoded (mun/format-stream muuntaja (get-in response [:headers "content-type"]) as body)]
+              (assoc response :body decoded)))]
     (fn decode-response-handler
       ([request]
        (prepare-response request (handler request)))


### PR DESCRIPTION
- Also use :text when not explicitly given for #4 and #3

This still attempts to do auto negotiation like I believe the original spirit of this library is. This just adds the ability to force the coercion to :text, :byte-array, and :stream. If you don't specify one and the auto negotiation fails, we use :text by default then to avoid issues such as #4 and is most likely what the end user would want.

This is a breaking change if you decide to merge it, however, given the age of the project and likely usage it may be OK to just bump the version to 1.x/0.2.x or document the breaking change?

If you're OK with this MR, let me know and I'll beef up unit tests around it.